### PR TITLE
Fixes for README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A fork of glpk that includes additional logging features for how cuts were gener
 - Currently the fork is from glpk-4.52
 
 - Compilation instructions:
+# libtoolize
 # aclocal
-# autoheaders
+# autoheader
 # autoconf
 # automake --add-missing
 # ./configure ...


### PR DESCRIPTION
By the way, I've noticed on both greed and on church that I need to run libtoolize on a fresh glpk-cut-log checkout, so the full instructions become as I've edited them here.  (Also typo "autoheader".)
