### PR TITLE
Update minisat.h ('bool' cannot be defined via 'typedef')

### DIFF
--- a/src/minisat/minisat.h
+++ b/src/minisat/minisat.h
@@ -34,10 +34,7 @@
 /*====================================================================*/
 /* Simple types: */
 
-typedef int bool;
-
-#define true  1
-#define false 0
+#include <stdbool.h>
 
 typedef int  lit;
 #if 0 /* by mao */


### PR DESCRIPTION
it gives error on build (it is possible it happens somewhere else) based on source it suggests <stdbool.h> as a c99+ compatible and indeed it compiles on my machine without errors.

source: https://gcc.gnu.org/gcc-15/porting_to.html#c23-new-keywords